### PR TITLE
Avoid unnecessary backtracking

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,7 +7,7 @@ const regenerate = require('regenerate');
 
 // PCENChar ::=
 //   "-" | "." | [0-9] | "_" | [a-z] | #xB7 | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x203F-#x2040] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
-const PCENCharRegenerate = regenerate('-', '.', '_', 0x00B7)
+const set = regenerate('-', '.', '_', 0x00B7)
 	.addRange('0', '9')
 	.addRange('a', 'z')
 	.addRange(0x00C0, 0x00D6)
@@ -22,8 +22,8 @@ const PCENCharRegenerate = regenerate('-', '.', '_', 0x00B7)
 	.addRange(0xF900, 0xFDCF)
 	.addRange(0xFDF0, 0xFFFD)
 	.addRange(0x010000, 0x0EFFFF);
-const PCENChar = PCENCharRegenerate.toString();
-const PCENCharNoHyphen = PCENCharRegenerate.clone().remove('-').toString();
+const PCENChar = set.toString();
+const PCENCharNoHyphen = set.clone().remove('-').toString();
 
 // PotentialCustomElementName ::=
 //   [a-z] (PCENChar)* '-' (PCENChar)*

--- a/build.js
+++ b/build.js
@@ -7,7 +7,7 @@ const regenerate = require('regenerate');
 
 // PCENChar ::=
 //   "-" | "." | [0-9] | "_" | [a-z] | #xB7 | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x203F-#x2040] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
-const PCENChar = regenerate('-', '.', '_', 0x00B7)
+const PCENCharRegenerate = regenerate('-', '.', '_', 0x00B7)
 	.addRange('0', '9')
 	.addRange('a', 'z')
 	.addRange(0x00C0, 0x00D6)
@@ -21,12 +21,14 @@ const PCENChar = regenerate('-', '.', '_', 0x00B7)
 	.addRange(0x3001, 0xD7FF)
 	.addRange(0xF900, 0xFDCF)
 	.addRange(0xFDF0, 0xFFFD)
-	.addRange(0x010000, 0x0EFFFF)
-	.toString();
+	.addRange(0x010000, 0x0EFFFF);
+const PCENChar = PCENCharRegenerate.toString();
+const PCENCharNoHyphen = PCENCharRegenerate.clone().remove('-').toString();
 
 // PotentialCustomElementName ::=
 //   [a-z] (PCENChar)* '-' (PCENChar)*
-const PotentialCustomElementName = `[a-z](?:${ PCENChar })*-(?:${ PCENChar })*`;
+// Note: The hyphen is omitted from the first group to avoid excess backtracking.
+const PotentialCustomElementName = `[a-z](?:${ PCENCharNoHyphen })*-(?:${ PCENChar })*`;
 const source = `// Generated using \`npm run build\`. Do not edit.
 
 var regex = /^${ PotentialCustomElementName }$/;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // Generated using `npm run build`. Do not edit.
 
-var regex = /^[a-z](?:[\-\.0-9_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*-(?:[\-\.0-9_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*$/;
+var regex = /^[a-z](?:[\.0-9_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*-(?:[\x2D\.0-9_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*$/;
 
 var isPotentialCustomElementName = function(string) {
 	return regex.test(string);

--- a/package.json
+++ b/package.json
@@ -24,10 +24,9 @@
     "url": "https://github.com/mathiasbynens/is-potential-custom-element-name.git"
   },
   "bugs": "https://github.com/mathiasbynens/is-potential-custom-element-name/issues",
-  "dependencies": {},
   "devDependencies": {
     "mocha": "^2.2.1",
-    "regenerate": "^1.3.1"
+    "regenerate": "^1.4.2"
   },
   "scripts": {
     "build": "node build.js",

--- a/test.js
+++ b/test.js
@@ -8,4 +8,9 @@ describe('is-potential-custom-element-name', function() {
 		assert.equal(isPotentialCustomElementName('baz-©'), false);
 		assert.equal(isPotentialCustomElementName('annotation-xml'), true);
 	});
+
+	it('avoids excess backtracking', function() {
+		const longA = 'a'.repeat(20000000);
+		assert.strictEqual(isPotentialCustomElementName('a-'.concat(longA)), true);
+	})
 });


### PR DESCRIPTION
Because `PCENChar` contains a hyphen, the resulting `RegExp` would first match all the `-`s using the first group, and then backtrack to match the middle `-` and the last group.

---

This makes it so that the first `PCENChar` excludes the hyphen, so that the hyphen is always matched by the middle hyphen in the `RegExp`.